### PR TITLE
Add Content-Type header to reshape middleware

### DIFF
--- a/lib/middleman-hashicorp/reshape.rb
+++ b/lib/middleman-hashicorp/reshape.rb
@@ -27,7 +27,7 @@ class ReshapeMiddleware
       # ok let's return the modified response now
       puts "processed '#{path}' with reshape"
       puts $?
-      return [200, {}, @response]
+      return [200, {'Content-Type'=> 'text/html'}, @response]
     else
       return [@status, @headers, @response]
     end


### PR DESCRIPTION
Adds `Content-Type: text/html` header to reshape middleware to help with testing locally (in this case, [Cypress](http://cypress.io) expects that header)