### PR TITLE
Escape html in meta descriptions

### DIFF
--- a/lib/middleman-hashicorp/extension.rb
+++ b/lib/middleman-hashicorp/extension.rb
@@ -4,6 +4,7 @@ module Middleman
     require_relative "releases"
     require_relative "rouge"
     require_relative "reshape"
+    require_relative "cgi"
   end
 end
 
@@ -166,7 +167,7 @@ class Middleman::HashiCorpExtension < ::Middleman::Extension
         # if the tag's name matches one of the override names, replace it
         if (name && overrides.keys.include?(name[1]))
           tag_type = name.to_s.include?('og:') ? 'property' : 'name'
-          acc.push("#{tag_type}=\"#{name[1]}\" content=\"#{overrides[name[1]]}\" />")
+          acc.push("#{tag_type}=\"#{CGI::escapeHTML(name[1])}\" content=\"#{CGI::escapeHTML(overrides[name[1]])}\" />")
         else
           # otherwise, leave the tag as-is
           acc.push(tag)


### PR DESCRIPTION
We had a recent issue where a double quote in a SEO description via CMS caused the html to break completely. This should take care of that!